### PR TITLE
docs(installation): add Docker Compose using Docker Hub Image

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,8 +4,6 @@ To run Airstation on your machine, there are two ways: using [Docker](https://do
 
 ## Docker
 
-> You can get pre-built image on [Docker Hub](https://hub.docker.com/r/cheatsnake/airstation/tags)
-
 1.  Clone Airstation repository
 
     ```sh
@@ -31,7 +29,7 @@ To run Airstation on your machine, there are two ways: using [Docker](https://do
     AIRSTATION_JWT_SIGN=
     ```
 
-    > `AIRSTATION_SECRET_KEY` - the secret key you need to log in to the station control panel <br> > `AIRSTATION_JWT_SIGN` - the key to sign the JWT session
+    > `AIRSTATION_SECRET_KEY` - the secret key you need to log in to the station control panel <br> `AIRSTATION_JWT_SIGN` - the key to sign the JWT session
 
     > Use [random string generator](https://it-tools.tech/token-generator?length=20) with a length of at least 10 characters for these variables!
 
@@ -54,10 +52,7 @@ docker compose down
 
 ### Docker Compose
 
-> [!TIP]
-> If you want to get something up & running quickly, you can use the [Docker Hub Image](https://hub.docker.com/r/cheatsnake/airstation) with this `docker-compose.yml` file.
->
-> - the default password for the [http://localhost:7331/studio/](http://localhost:7331/studio/) dashboard is `letmeinplease`, which can be changed via your own `.env` file in the same directory as the `docker-compose.yml` file.
+You can get pre-built image from [Docker Hub](https://hub.docker.com/r/cheatsnake/airstation) and run it quickly with custom `docker-compose.yml` file as shown bellow:
 
 ```yml
 # docker-compose.yml
@@ -71,8 +66,8 @@ services:
       - ./static:/app/static
     restart: unless-stopped
     environment:
-      AIRSTATION_SECRET_KEY: ${AIRSTATION_SECRET_KEY:-letmeinplease}
-      AIRSTATION_JWT_SIGN: ${AIRSTATION_JWT_SIGN:-thisisasecretforhashing}
+      AIRSTATION_SECRET_KEY: ${AIRSTATION_SECRET_KEY:-PASTE_YOUR_OWN_KEY}
+      AIRSTATION_JWT_SIGN: ${AIRSTATION_JWT_SIGN:-PASTE_RANDOM_STRING}
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:7331/"]
       interval: 10s
@@ -83,6 +78,8 @@ services:
 volumes:
   airstation-data:
 ```
+
+> Don't forget to modify environment variables inside this file or via your own `.env` file in the same directory as the `docker-compose.yml`
 
 ## Build from source
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,15 +24,14 @@ To run Airstation on your machine, there are two ways: using [Docker](https://do
     touch .env
     ```
 
-    Inside this file you must define 2 variables: 
+    Inside this file you must define 2 variables:
 
     ```
     AIRSTATION_SECRET_KEY=
     AIRSTATION_JWT_SIGN=
     ```
 
-    > `AIRSTATION_SECRET_KEY` - the secret key you need to log in to the station control panel <br>
-    > `AIRSTATION_JWT_SIGN` - the key to sign the JWT session
+    > `AIRSTATION_SECRET_KEY` - the secret key you need to log in to the station control panel <br> > `AIRSTATION_JWT_SIGN` - the key to sign the JWT session
 
     > Use [random string generator](https://it-tools.tech/token-generator?length=20) with a length of at least 10 characters for these variables!
 
@@ -42,7 +41,7 @@ To run Airstation on your machine, there are two ways: using [Docker](https://do
     docker compose up -d
     ```
 
-And finally you can see: 
+And finally you can see:
 
 - Control panel on [http://localhost:7331/studio/](http://localhost:7331/studio/) (extra slash matters!)
 - Radio player on [http://localhost:7331](http://localhost:7331)
@@ -51,6 +50,38 @@ To stop the container, just type:
 
 ```sh
 docker compose down
+```
+
+### Docker Compose
+
+> [!TIP]
+> If you want to get something up & running quickly, you can use the [Docker Hub Image](https://hub.docker.com/r/cheatsnake/airstation) with this `docker-compose.yml` file.
+>
+> - the default password for the [http://localhost:7331/studio/](http://localhost:7331/studio/) dashboard is `letmeinplease`, which can be changed via your own `.env` file in the same directory as the `docker-compose.yml` file.
+
+```yml
+# docker-compose.yml
+services:
+  airstation:
+    image: cheatsnake/airstation:latest
+    ports:
+      - "7331:7331"
+    volumes:
+      - airstation-data:/app/storage
+      - ./static:/app/static
+    restart: unless-stopped
+    environment:
+      AIRSTATION_SECRET_KEY: ${AIRSTATION_SECRET_KEY:-letmeinplease}
+      AIRSTATION_JWT_SIGN: ${AIRSTATION_JWT_SIGN:-thisisasecretforhashing}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7331/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+volumes:
+  airstation-data:
 ```
 
 ## Build from source


### PR DESCRIPTION
I saw that this project has a [Docker Hub Image](https://hub.docker.com/r/cheatsnake/airstation), so I thought I'd make a `docker-compose.yml` file that people can easily copy & run on their machines.

Likewise, for anyone using [Coolify](https://github.com/coollabsio/coolify), they can use this Docker Compose file instead:

```yml
services:
  airstation:
    image: 'cheatsnake/airstation:latest'
    volumes:
      - 'airstation-data:/app/storage'
      - 'airstation-data:/app/static'
    restart: unless-stopped
    environment:
      - SERVICE_FQDN_AIRSTATION_7331
      - AIRSTATION_SECRET_KEY=${AIRSTATION_SECRET_KEY:-letmeinplease}
      - AIRSTATION_JWT_SIGN=${AIRSTATION_JWT_SIGN:-thisisasecretforhashing}
    healthcheck:
      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7331/"]
      interval: 10s
      timeout: 5s
      retries: 3
      start_period: 10s
volumes:
  airstation-data: null
  ```