### PR TITLE
Fix HLS playback on Safari and iOS (fixes #23)

### DIFF
--- a/web/player/src/page/RadioButton.tsx
+++ b/web/player/src/page/RadioButton.tsx
@@ -36,6 +36,14 @@ export const RadioButton = () => {
 
     const handlePause = () => {
         setTrackStore("isPlay", false);
+        if (hls) {
+            hls.destroy();
+            hls = undefined;
+            if (videoRef) {
+                videoRef.removeAttribute("src");
+                videoRef.load();
+            }
+        }
     };
 
     onMount(() => {
@@ -52,6 +60,7 @@ export const RadioButton = () => {
             addHistory({ id: unixTime, playedAt: unixTime, trackName: e.data });
 
             if (trackStore.isPlay) (() => videoRef?.pause())();
+            initStream();
             // On the native-HLS path the first /stream fetch may have returned an empty
             // playlist (server was idle). Force Safari to refetch now that a track is playing.
             if (videoRef && canPlayNativeHls(videoRef)) {
@@ -64,7 +73,12 @@ export const RadioButton = () => {
         document.body.addEventListener("keydown", (event) => {
             if (event.key === " ") {
                 event.preventDefault();
-                trackStore.isPlay ? videoRef?.pause() : videoRef?.play();
+                if (trackStore.isPlay) {
+                    videoRef?.pause();
+                } else {
+                    initStream();
+                    videoRef?.play();
+                }
             }
         });
     });
@@ -76,7 +90,15 @@ export const RadioButton = () => {
                 {trackStore.isPlay ? (
                     <AnimatedPauseButton pause={() => videoRef?.pause()} media={videoRef} />
                 ) : (
-                    <div class={styles.play_icon} tabIndex={0} role="button" onClick={() => videoRef?.play()}></div>
+                    <div
+                        class={styles.play_icon}
+                        tabIndex={0}
+                        role="button"
+                        onClick={() => {
+                            initStream();
+                            videoRef?.play();
+                        }}
+                    ></div>
                 )}
             </div>
         </div>

--- a/web/player/src/page/RadioButton.tsx
+++ b/web/player/src/page/RadioButton.tsx
@@ -7,6 +7,7 @@ import { getUnixTime } from "../utils/date";
 import { addHistory } from "../store/history";
 import { getCssVariable } from "../utils/document";
 import { getHueFromHex } from "../utils/color";
+import { canPlayNativeHls } from "../utils/platform";
 
 const STREAM_SOURCE = "/stream";
 
@@ -15,7 +16,13 @@ export const RadioButton = () => {
     let hls: HLS | undefined;
 
     const initStream = () => {
-        if (!trackStore.isPlay && HLS.isSupported()) {
+        if (!videoRef || hls || videoRef.src) return;
+
+        // Prefer native HLS on Safari (iOS/macOS). macOS Safari advertises MSE so
+        // Hls.isSupported() is true, but hls.js's attachMedia throws AbortError on WebKit.
+        if (canPlayNativeHls(videoRef)) {
+            videoRef.src = STREAM_SOURCE;
+        } else if (HLS.isSupported()) {
             hls = new HLS();
             hls.loadSource(STREAM_SOURCE);
             hls.attachMedia(videoRef as unknown as HTMLMediaElement);
@@ -23,17 +30,17 @@ export const RadioButton = () => {
     };
 
     const handlePlay = () => {
-        initStream();
         if (!trackStore.trackName) return;
         setTrackStore("isPlay", true);
     };
 
     const handlePause = () => {
         setTrackStore("isPlay", false);
-        hls?.destroy();
     };
 
     onMount(() => {
+        initStream();
+
         addEventListener(EVENTS.pause, (_e: MessageEvent<string>) => {
             setTrackStore("trackName", "");
             (() => videoRef?.pause())();
@@ -45,6 +52,12 @@ export const RadioButton = () => {
             addHistory({ id: unixTime, playedAt: unixTime, trackName: e.data });
 
             if (trackStore.isPlay) (() => videoRef?.pause())();
+            // On the native-HLS path the first /stream fetch may have returned an empty
+            // playlist (server was idle). Force Safari to refetch now that a track is playing.
+            if (videoRef && canPlayNativeHls(videoRef)) {
+                videoRef.src = STREAM_SOURCE;
+                videoRef.load();
+            }
             (() => videoRef?.play())();
         });
 

--- a/web/player/src/utils/platform.ts
+++ b/web/player/src/utils/platform.ts
@@ -1,0 +1,4 @@
+// Feature detection for native HLS playback. Returns true on Safari (iOS/macOS),
+// false on Chrome/Firefox/Edge. Prefer this over UA sniffing for source selection.
+export const canPlayNativeHls = (el: HTMLMediaElement | null | undefined): boolean =>
+    !!el && !!el.canPlayType("application/vnd.apple.mpegurl");

--- a/web/studio/src/page/Playback.tsx
+++ b/web/studio/src/page/Playback.tsx
@@ -24,6 +24,7 @@ import { SettingsModal } from "./Settings";
 import Hls from "hls.js";
 import { modals } from "@mantine/modals";
 import styles from "./styles.module.css";
+import { canPlayNativeHls } from "../utils/platform";
 
 export const Playback: FC<{ isMobile?: boolean }> = (props) => {
     const updateIntervalID = useRef(0);
@@ -176,42 +177,66 @@ const ListenerCounter = () => {
 const StreamToggler: FC<{ playback: PlaybackState; size: MantineSize }> = (props) => {
     const videoRef = useRef<HTMLAudioElement | null>(null);
     const streamRef = useRef<Hls | null>(null);
+    const primedRef = useRef(false);
     const [isPlaying, setIsPlaying] = useState(false);
 
-    const initStream = () => {
-        if (isPlaying) return;
+    const STREAM_URL = API_HOST + "/stream";
 
-        streamRef.current = new Hls();
-        streamRef.current.loadSource(API_HOST + "/stream");
-        streamRef.current.attachMedia(videoRef.current as unknown as HTMLMediaElement);
+    // Prefer native HLS on Safari (iOS/macOS). macOS Safari advertises MSE so
+    // Hls.isSupported() is true, but hls.js's attachMedia throws AbortError on WebKit.
+    const initStream = () => {
+        const el = videoRef.current;
+        if (!el || primedRef.current) return;
+
+        if (canPlayNativeHls(el)) {
+            el.src = STREAM_URL;
+        } else if (Hls.isSupported()) {
+            streamRef.current = new Hls();
+            streamRef.current.loadSource(STREAM_URL);
+            streamRef.current.attachMedia(el as unknown as HTMLMediaElement);
+        } else {
+            return;
+        }
+        primedRef.current = true;
     };
 
+    // Setting .src = "" does not actually detach media in Safari (getter returns
+    // the document URL). removeAttribute + load() is the canonical detach.
     const destroyStream = () => {
         streamRef.current?.destroy();
         streamRef.current = null;
+        const el = videoRef.current;
+        if (el) {
+            el.pause();
+            el.removeAttribute("src");
+            el.load();
+        }
+        primedRef.current = false;
         setIsPlaying(false);
     };
 
-    const handlePause = () => {
-        videoRef.current?.pause();
-        destroyStream();
-    };
+    const handlePause = () => setIsPlaying(false);
+    const handlePlay = () => setIsPlaying(true);
 
-    const handlePlay = async () => {
+    const toggle = async () => {
+        const el = videoRef.current;
+        if (!el) return;
+        if (isPlaying) {
+            el.pause();
+            return;
+        }
+        initStream();
         try {
-            initStream();
-            await videoRef.current?.play();
-            setIsPlaying(true);
+            await el.play();
         } catch (error) {
             console.log("Failed to play: ", error);
         }
     };
 
     useEffect(() => {
-        if (!props.playback.isPlaying && streamRef.current) {
-            destroyStream();
-        }
-    }, [props.playback]);
+        if (props.playback.isPlaying) initStream();
+        else destroyStream();
+    }, [props.playback.isPlaying]);
 
     return (
         <>
@@ -225,7 +250,7 @@ const StreamToggler: FC<{ playback: PlaybackState; size: MantineSize }> = (props
             <Tooltip openDelay={500} label={`${isPlaying ? "Mute" : "Unmute"} the stream just for me`}>
                 <ActionIcon
                     variant="subtle"
-                    onClick={isPlaying ? () => videoRef.current?.pause() : () => videoRef.current?.play()}
+                    onClick={toggle}
                     color="gray"
                     size={props.size}
                     aria-label="Settings"

--- a/web/studio/src/utils/platform.ts
+++ b/web/studio/src/utils/platform.ts
@@ -1,0 +1,4 @@
+// Feature detection for native HLS playback. Returns true on Safari (iOS/macOS),
+// false on Chrome/Firefox/Edge. Prefer this over UA sniffing for source selection.
+export const canPlayNativeHls = (el: HTMLMediaElement | null | undefined): boolean =>
+    !!el && !!el.canPlayType("application/vnd.apple.mpegurl");


### PR DESCRIPTION
## Summary

Fixes #23. Playback never starts on Safari (iOS and macOS). Chrome and Firefox were unaffected. The fix touches both the listener **player** and the admin **studio**, since the same underlying HLS-selection bug existed in both. Verified manually on Safari macOS and iOS (player) and Safari macOS (studio Unmute), with Chrome/Firefox unchanged.

## Root cause (two bugs, same symptom)

### 1. Source selection preferred hls.js even on Safari macOS

Both `web/player/src/page/RadioButton.tsx` and `web/studio/src/page/Playback.tsx` started HLS by unconditionally taking the `Hls.isSupported()` branch. On **macOS Safari** that returns `true` because MSE is exposed, so the code called `Hls.attachMedia()`, which throws `AbortError: The operation was aborted` on WebKit. On **iOS Safari** MSE is not exposed, so the code fell through with no source ever attached, the audio element stayed empty and `play()` had nothing to play.

This matches exactly what @cheatsnake observed:
```
{canPlayNativeHls: false, hlsIsSupported: true, mseIsSupported: true}
Unhandled Promise Rejection: AbortError: The operation was aborted. onMediaAttaching, hls.mjs
```

### 2. Studio detach left the audio element half-attached

`StreamToggler` in `Playback.tsx` cleared the stream with `videoRef.current.src = ""` when server playback stopped. In Safari that does **not** actually detach media: the `.src` getter resolves `""` against the document URL, so the next `initStream` call saw a truthy `src` and skipped wiring `/stream`. Result: the audio element never had a real source, `play()` was a silent no-op, and no `/stream` request ever fired (confirmed via HAR capture).

## The fix

### Prefer native HLS on Safari, fall back to hls.js elsewhere

The canonical hls.js recipe flipped:

```ts
if (canPlayNativeHls(videoRef)) {
    videoRef.src = STREAM_SOURCE;        // Safari (iOS/macOS): native HLS
} else if (HLS.isSupported()) {
    hls = new HLS();                      // Chrome/Firefox/Edge: hls.js + MSE
    hls.loadSource(STREAM_SOURCE);
    hls.attachMedia(videoRef as unknown as HTMLMediaElement);
}
```

`canPlayNativeHls()` is a shared utility added at `web/{player,studio}/src/utils/platform.ts` that just wraps `audio.canPlayType("application/vnd.apple.mpegurl")`. Feature detection covers every browser we care about without UA sniffing.

### Correct detach in the studio

Switched from the broken `src = ""` to the canonical `removeAttribute("src") + load()`, backed by a `primedRef` flag instead of introspecting `.src`:

```ts
const destroyStream = () => {
    streamRef.current?.destroy();
    streamRef.current = null;
    const el = videoRef.current;
    if (el) { el.pause(); el.removeAttribute("src"); el.load(); }
    primedRef.current = false;
    setIsPlaying(false);
};
```

### Other follow-ups in the same commit

- Player primes the stream in `onMount` so `videoRef.play()` has a source to consume on the very first user gesture.
- On the SSE `play` event the player force-reloads the native-HLS source (`src = ...; load()`) so Safari refetches a previously-empty playlist when the server transitions from idle to playing.
- Studio Unmute button now goes through a single `toggle()` that primes before calling `play()`, avoiding the old race where `play()` ran with an empty `.src`.

## Verification

- `npm run build` passes for both `web/player` and `web/studio` (tsc + vite, no warnings).
- Manual checks on macOS Safari: player unmute + studio Unmute both produce audio, with both "server playing at page load" and "server idle at page load, track starts later" scenarios.
- Manual check on iOS Safari (player): produces audio.
- Chrome and Firefox still take the hls.js path, behavior unchanged.

## Test plan

- [ ] Safari macOS, player: playback starts when server is already playing at page load.
- [ ] Safari macOS, player: playback starts when server is idle at page load and a track starts afterwards.
- [ ] Safari macOS, studio: Unmute produces audio.
- [ ] Safari iOS (iPhone and iPad): player playback in both scenarios above.
- [ ] Chrome/Firefox desktop: player and studio still go through hls.js unchanged.
- [ ] Pause/resume and SSE pause/play events still work on both paths.